### PR TITLE
CLI Basic Features 

### DIFF
--- a/cli/list.py
+++ b/cli/list.py
@@ -1,0 +1,114 @@
+import argparse
+import os
+import requests
+import sys
+from bs4 import BeautifulSoup 
+from typing import Dict
+
+from .utils import _build_pkg_url
+
+
+def fetch_pkg_version(pkg_url: str, category: str) -> str: 
+    """
+    Find the version of package documentation 
+
+    :param pkg_url: Full URL of package documentation 
+    :param category: If ``pkg_name`` has docs in multiple languages, 
+        the language for which to get docs.
+    :return: version string of the package requested 
+    """
+    # default HTML parsing arguments
+    VERSION_TAG = {
+        # assuming pkgdown for R 
+        'r': {
+            'name': 'span', 
+            'class_': 'label label-default'
+        }, 
+        # assuming readthedocs style for Python 
+        'python': {
+            'name': 'div', 
+            'class_': 'version'
+        }
+    }
+    # fetch the page and parse version 
+    page = requests.get(pkg_url) 
+    soup = BeautifulSoup(page.content, 'html.parser')
+    version = soup.find_all(**VERSION_TAG[category.lower()])[0].get_text().strip()
+    return str(version)
+
+
+def fetch_table_of_contents(host: str) -> Dict[str, Dict[str, str]]: 
+    """
+    Fetch the table of contents from the host homepage 
+
+    :param host: URL of updoc host
+    :return: Table of contents of all documentations available on the host 
+    """
+    # get table of contents 
+    # home_endpt = f'{host}/available'
+    home_endpt = host + '/available'
+    res = requests.get(home_endpt)
+    table_of_contents = res.json() 
+    return {
+        item['category']: {
+            doc['doc_name']: doc['doc_path'] 
+            for doc in item['documents']
+        }
+        for item in table_of_contents
+    }
+
+
+def _main(arg_list):
+    parser = argparse.ArgumentParser(description="""
+    Query information from updoc host. The URL to the updoc host should be 
+    stored in an environment variable named `UPDOC_HOST`. 
+    """)
+
+    parser.add_argument("-c", "--category", help="Language of package, e.g. `r` or `python`")
+    parser.add_argument("-p", "--package", help="Package whose documentation to open")
+    parser.add_argument("-v", "--version", help="Query version of the package", action="store_true")
+
+    args = parser.parse_args(arg_list)
+
+    if args.category is None and args.package is None and not args.version: 
+        # list all categories on updoc host 
+        toc = fetch_table_of_contents(host=os.environ['UPDOC_HOST'])
+        return list(toc.keys())
+    elif args.category is not None and args.package is None and not args.version: 
+        # list all documentations within a category on updoc host 
+        toc = fetch_table_of_contents(host=os.environ['UPDOC_HOST'])
+        if args.category in toc: 
+            return list(toc[args.category].keys())
+        else: 
+            return 'Invalid category' 
+    elif args.category is not None and args.package is not None and not args.version: 
+        # list a documentation's full URL on updoc host 
+        toc = fetch_table_of_contents(host=os.environ['UPDOC_HOST'])
+        if args.category in toc and args.package in toc[args.category]: 
+            pkg_url = _build_pkg_url(
+                host=os.environ['UPDOC_HOST'], 
+                category=args.category, 
+                pkg_name=args.package
+            )
+            return pkg_url
+        else: 
+            return 'Requested package not found in the category'
+    elif args.category is not None and args.package is not None and args.version: 
+        # list the version of a package documentation on updoc host 
+        version = fetch_pkg_version(
+            pkg_url=_build_pkg_url(
+                host=os.environ['UPDOC_HOST'], 
+                category=args.category, 
+                pkg_name=args.package
+            ), 
+            category=args.category
+        )
+        return version 
+
+
+def _cli():
+    _main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    _cli()

--- a/cli/open.py
+++ b/cli/open.py
@@ -3,35 +3,38 @@ import os
 import sys
 import webbrowser
 
+from .utils import _build_pkg_url
 
-def open_docs(package: str, language: str, host: str):
+
+def open_docs(host: str, category: str, pkg_name: str):
     """
     Open docs hosted on updoc
 
-    :param package: String of package whose docs to open
-    :param language: If ``package`` has docs in multiple languages, the language for which to get
-        docs.
+    :param pkg_name: String of package whose docs to open
+    :param category: If ``pkg_name`` has docs in multiple languages, 
+        the language for which to get docs.
     :param host: URL of updoc host
     """
-    if host[-1] != "/":
-        host += "/"
-
-    url = f"{host}static/{language.title()}/{package}/index.html"
+    url = _build_pkg_url(
+        host=host, 
+        category=category, 
+        pkg_name=pkg_name
+    )
     webbrowser.open_new_tab(url=url)
 
 
 def _main(arg_list):
     parser = argparse.ArgumentParser(description="""
-    Open docs hosted on updoc. The URL to the updoc host should be stored in an environment variable 
-    named `UPDOC_HOST`. 
+    Open docs hosted on updoc. The URL to the updoc host should be 
+    stored in an environment variable named `UPDOC_HOST`. 
     """)
 
-    parser.add_argument("-l", "--language", help="Language of package, e.g. `r` or `python`")
-    parser.add_argument("package", help="Package whose documentation to open")
+    parser.add_argument("-c", "--category", help="Language of package, e.g. `r` or `python`")
+    parser.add_argument("-p", "--package", help="Package whose documentation to open")
 
     args = parser.parse_args(arg_list)
 
-    open_docs(package=args.package, language=args.language, host=os.environ['UPDOC_HOST'])
+    open_docs(host=os.environ['UPDOC_HOST'], category=args.category, pkg_name=args.package)
 
 
 def _cli():

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,0 +1,13 @@
+def _format_host(host: str) -> str: 
+    return host + "/" if host[-1] != "/" else host 
+
+
+def _build_pkg_url(host: str, category: str, pkg_name: str) -> str: 
+    # return f'{host}static/{category}/{pkg_name}/index.html'
+    return (
+        _format_host(host)          # e.g. https://docs.your_company.com
+        + 'static/'                 # updoc format 
+        + category.title() + '/'    # typically language, e.g. Python or R 
+        + pkg_name + '/'            # package name 
+        + 'index.html'              # updoc format, doc's index.html is entry pt 
+    )

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,13 +1,17 @@
 def _format_host(host: str) -> str: 
-    return host + "/" if host[-1] != "/" else host 
+    if host[-1] != "/":
+        host += "/"
+        
+    return host
 
 
 def _build_pkg_url(host: str, category: str, pkg_name: str) -> str: 
+    """
+    Assemble docs URL for package
+    
+    :param host: e.g. https://docs.your_company.com/ 
+    :param category: typically language, e.g. Python or R 
+    :param pkg_name: package name 
+    """
     # return f'{host}static/{category}/{pkg_name}/index.html'
-    return (
-        _format_host(host)          # e.g. https://docs.your_company.com/ 
-        + 'static/'                 # updoc format 
-        + category.title() + '/'    # typically language, e.g. Python or R 
-        + pkg_name + '/'            # package name 
-        + 'index.html'              # updoc format, doc's index.html is entry pt 
-    )
+    return f"{_format_host(host)}static/{category.title()}/{pkg_name}/index.html'

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -5,7 +5,7 @@ def _format_host(host: str) -> str:
 def _build_pkg_url(host: str, category: str, pkg_name: str) -> str: 
     # return f'{host}static/{category}/{pkg_name}/index.html'
     return (
-        _format_host(host)          # e.g. https://docs.your_company.com
+        _format_host(host)          # e.g. https://docs.your_company.com/ 
         + 'static/'                 # updoc format 
         + category.title() + '/'    # typically language, e.g. Python or R 
         + pkg_name + '/'            # package name 


### PR DESCRIPTION
@alistaire47: Thanks for putting together the format for a CLI. I put together some basic features as we discussed before. 

- `open.py` enables 
```bash 
updoc open --category r --package httr 
```
- `list.py` enables 
    - list all categories 
    ```bash
    updoc list 
    ```
    - list all docs within a category  
    ```bash
    updoc list --category r 
    ```
    - prints the full URL of a doc 
    ```bash
    updoc list --category r --package httr 
    ```
    - prints the version of a doc 
    ```bash
    updoc list --category r --package httr --version   
    ```
- `utils.py`: maybe we should also include some category aliasing here? e.g. `py` --> `python`. 